### PR TITLE
Remember and initially select as defaults the last context names selected by user.

### DIFF
--- a/src/cmd/get/context/context.go
+++ b/src/cmd/get/context/context.go
@@ -26,7 +26,17 @@ func run(names []string) error {
 		return err
 	}
 
-	names, err = cmd.GetOrPromptContextNames(contexts, names)
+	lastNames, err := cmd.LoadLastNames()
+	if err != nil {
+		return err
+	}
+
+	names, err = cmd.GetOrPromptContextNames(contexts, names, lastNames)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.SaveLastNames(names)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/last.go
+++ b/src/cmd/last.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+func getLastNamesFilePath() (string, error) {
+	return homedir.Expand("~/.yeylast")
+}
+
+// SaveLastNames saves to home dir the context names that were last selected by user
+func SaveLastNames(names []string) error {
+	file, err := getLastNamesFilePath()
+	if err != nil {
+		return fmt.Errorf("failed to determine last context names file path: %w", err)
+	}
+
+	err = ioutil.WriteFile(file, ([]byte)(strings.Join(names, " ")), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write last context names file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadLastNames loads from home dir the context names that were last selected by user
+func LoadLastNames() ([]string, error) {
+	file, err := getLastNamesFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine last context names file path: %w", err)
+	}
+
+	text, err := ioutil.ReadFile(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read last context names file: %w", err)
+	}
+
+	return strings.Split((string)(text), " "), nil
+}

--- a/src/cmd/prompts.go
+++ b/src/cmd/prompts.go
@@ -8,7 +8,11 @@ import (
 )
 
 // Parses given value into context name and variant and, as needed, prompt user for those values
-func GetOrPromptContextNames(contexts yey.Contexts, names []string) ([]string, error) {
+func GetOrPromptContextNames(contexts yey.Contexts, names []string, lastNames []string) ([]string, error) {
+	if len(names) == 1 && names[0] == "-" {
+		return lastNames, nil
+	}
+
 	availableNames := contexts.GetNamesInAllLayers()
 
 	// Prompt unspecified names
@@ -21,6 +25,9 @@ func GetOrPromptContextNames(contexts yey.Contexts, names []string) ([]string, e
 		prompt := &survey.Select{
 			Message: fmt.Sprintf("Select %s:", contexts.Layers[i].Name),
 			Options: availableNames[i],
+		}
+		if i < len(lastNames) {
+			prompt.Default = lastNames[i]
 		}
 		selectedIndex := 0
 		if err := survey.AskOne(prompt, &selectedIndex); err != nil {

--- a/src/cmd/remove/remove.go
+++ b/src/cmd/remove/remove.go
@@ -36,9 +36,19 @@ func run(ctx context.Context, names []string, options docker.RemoveOptions) erro
 		return err
 	}
 
-	names, err = cmd.GetOrPromptContextNames(contexts, names)
+	lastNames, err := cmd.LoadLastNames()
 	if err != nil {
-		return fmt.Errorf("failed to prompt for context: %w", err)
+		return err
+	}
+
+	names, err = cmd.GetOrPromptContextNames(contexts, names, lastNames)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.SaveLastNames(names)
+	if err != nil {
+		return err
 	}
 
 	context, err := contexts.GetContext(names)

--- a/src/cmd/run/run.go
+++ b/src/cmd/run/run.go
@@ -47,7 +47,17 @@ func run(ctx context.Context, names []string, options Options) error {
 		return err
 	}
 
-	names, err = cmd.GetOrPromptContextNames(contexts, names)
+	lastNames, err := cmd.LoadLastNames()
+	if err != nil {
+		return err
+	}
+
+	names, err = cmd.GetOrPromptContextNames(contexts, names, lastNames)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.SaveLastNames(names)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Remember and initially select as defaults the last context names selected by user. Also allow user to specify "yey run -" to automatically use last context names, exactly like "cd -" and other commands.