### PR TITLE
Multi-select context names for yey rm

### DIFF
--- a/src/cmd/get/containers/containers.go
+++ b/src/cmd/get/containers/containers.go
@@ -3,8 +3,10 @@ package containers
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/TwinProduction/go-color"
 	"github.com/spf13/cobra"
 
 	"github.com/silphid/yey/src/internal/docker"
@@ -26,6 +28,10 @@ func run(ctx context.Context) error {
 	names, err := docker.ListContainers(ctx)
 	if err != nil {
 		return err
+	}
+	if len(names) == 0 {
+		fmt.Fprintln(os.Stderr, color.Ize(color.Green, "no yey containers found"))
+		return nil
 	}
 	fmt.Println(strings.Join(names, "\n"))
 	return nil

--- a/src/cmd/prompts.go
+++ b/src/cmd/prompts.go
@@ -12,24 +12,65 @@ func GetOrPromptContextNames(contexts yey.Contexts, names []string) ([]string, e
 	availableNames := contexts.GetNamesInAllLayers()
 
 	// Prompt unspecified names
-	for i := len(names); i < len(contexts.Layers); i++ {
+	for layer := len(names); layer < len(contexts.Layers); layer++ {
 		// Don't prompt when single name in layer
-		if len(availableNames[i]) == 1 {
-			names = append(names, availableNames[i][0])
+		if len(availableNames[layer]) == 1 {
+			names = append(names, availableNames[layer][0])
 			continue
 		}
 		prompt := &survey.Select{
-			Message: fmt.Sprintf("Select %s", contexts.Layers[i].Name),
-			Options: availableNames[i],
+			Message: fmt.Sprintf("Select %s", contexts.Layers[layer].Name),
+			Options: availableNames[layer],
 		}
-		selectedIndex := 0
-		if err := survey.AskOne(prompt, &selectedIndex); err != nil {
+		var selectedName string
+		if err := survey.AskOne(prompt, &selectedName); err != nil {
 			return nil, err
 		}
-		names = append(names, availableNames[i][selectedIndex])
+		names = append(names, selectedName)
 	}
 
 	return names, nil
+}
+
+// Parses given value into context name and variant and, as needed, prompt user for those values
+func GetOrPromptMultipleContextNames(contexts yey.Contexts, names []string, predicate func(name string, layer int) bool) ([][]string, error) {
+	availableNames := contexts.GetNamesInAllLayers()
+
+	outputNames := make([][]string, 0, len(contexts.Layers))
+	for layer := 0; layer < len(contexts.Layers); layer++ {
+		// Context name for this layer already specified by user?
+		if layer < len(names) {
+			// Just take name specified by user
+			outputNames = append(outputNames, []string{names[layer]})
+		} else {
+			// Filter context names through predicate
+			filteredNames := make([]string, 0, len(availableNames[layer]))
+			for _, name := range availableNames[layer] {
+				if predicate(name, layer) {
+					filteredNames = append(filteredNames, name)
+				}
+			}
+
+			// Don't prompt when single option
+			if len(filteredNames) == 1 {
+				outputNames = append(outputNames, filteredNames)
+				continue
+			}
+
+			// Prompt to multiselect context names for unspecified layer
+			prompt := &survey.MultiSelect{
+				Message: fmt.Sprintf("Select %s(s)", contexts.Layers[layer].Name),
+				Options: filteredNames,
+			}
+			var selectedNames []string
+			if err := survey.AskOne(prompt, &selectedNames); err != nil {
+				return nil, err
+			}
+			outputNames = append(outputNames, selectedNames)
+		}
+	}
+
+	return outputNames, nil
 }
 
 // Prompts user to multi-select among given images

--- a/src/cmd/prompts.go
+++ b/src/cmd/prompts.go
@@ -26,8 +26,8 @@ func GetOrPromptContextNames(contexts yey.Contexts, names []string, lastNames []
 			Message: fmt.Sprintf("Select %s", contexts.Layers[layer].Name),
 			Options: availableNames[layer],
 		}
-		if i < len(lastNames) {
-			prompt.Default = lastNames[i]
+		if layer < len(lastNames) {
+			prompt.Default = lastNames[layer]
 		}
 		var selectedName string
 		if err := survey.AskOne(prompt, &selectedName); err != nil {
@@ -40,7 +40,7 @@ func GetOrPromptContextNames(contexts yey.Contexts, names []string, lastNames []
 }
 
 // Parses given value into context name and variant and, as needed, prompt user for those values
-func GetOrPromptMultipleContextNames(contexts yey.Contexts, names []string, predicate func(name string, layer int) bool) ([][]string, error) {
+func GetOrPromptMultipleContextNames(contexts yey.Contexts, names []string, predicate func(name string) bool) ([][]string, error) {
 	availableNames := contexts.GetNamesInAllLayers()
 
 	outputNames := make([][]string, 0, len(contexts.Layers))
@@ -53,7 +53,7 @@ func GetOrPromptMultipleContextNames(contexts yey.Contexts, names []string, pred
 			// Filter context names through predicate
 			filteredNames := make([]string, 0, len(availableNames[layer]))
 			for _, name := range availableNames[layer] {
-				if predicate(name, layer) {
+				if predicate(name) {
 					filteredNames = append(filteredNames, name)
 				}
 			}

--- a/src/cmd/remove/remove.go
+++ b/src/cmd/remove/remove.go
@@ -3,7 +3,10 @@ package remove
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/TwinProduction/go-color"
 	"github.com/spf13/cobra"
 
 	"github.com/silphid/yey/src/cmd"
@@ -36,11 +39,63 @@ func run(ctx context.Context, names []string, options docker.RemoveOptions) erro
 		return err
 	}
 
-	names, err = cmd.GetOrPromptContextNames(contexts, names)
+	containers, err := docker.ListContainers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list containers to prompt for removal: %w", err)
+	}
+
+	// Abort if no containers to remove
+	if len(containers) == 0 {
+		fmt.Fprintln(os.Stderr, color.Ize(color.Green, "no containers to remove"))
+		return nil
+	}
+
+	// Parse container names to slices
+	containerNames := make([][]string, len(containers))
+	for i, container := range containers {
+		// TODO: improve this logic to support context names with dashes in them
+		// We need a more deterministic way to trace back a container name to its context names
+		containerNames[i] = strings.Split(container, "-")
+	}
+
+	// Predicate to determine whether context name in given layer has a corresponding container
+	predicate := func(name string, layer int) bool {
+		for _, containerName := range containerNames {
+			skipContainerPrefixes := 3
+			if containerName[skipContainerPrefixes+layer] == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Prompt
+	selectedNames, err := cmd.GetOrPromptMultipleContextNames(contexts, names, predicate)
 	if err != nil {
 		return fmt.Errorf("failed to prompt for context: %w", err)
 	}
 
+	return removeRecursively(ctx, contexts, selectedNames, []string{}, 0, options)
+}
+
+func removeRecursively(ctx context.Context, contexts yey.Contexts, selectedNames [][]string, names []string, layer int, options docker.RemoveOptions) error {
+	for _, name := range selectedNames[layer] {
+		currentNames := append(names, name)
+		var err error
+		if layer == len(selectedNames)-1 {
+			err = remove(ctx, contexts, currentNames, options)
+		} else {
+			// Recurse
+			err = removeRecursively(ctx, contexts, selectedNames, currentNames, layer+1, options)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func remove(ctx context.Context, contexts yey.Contexts, names []string, options docker.RemoveOptions) error {
 	context, err := contexts.GetContext(names)
 	if err != nil {
 		return fmt.Errorf("failed to get context: %w", err)
@@ -48,5 +103,6 @@ func run(ctx context.Context, names []string, options docker.RemoveOptions) erro
 
 	container := yey.ContainerName(contexts.Path, context)
 
+	yey.Log("Removing %s", container)
 	return docker.Remove(ctx, container, options)
 }

--- a/src/internal/docker/cli.go
+++ b/src/internal/docker/cli.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	yey "github.com/silphid/yey/src/internal"
@@ -100,12 +101,21 @@ var newlines = regexp.MustCompile(`\r?\n`)
 
 func ListContainers(ctx context.Context) ([]string, error) {
 	cmd := exec.Command("docker", "ps", "--all", "--filter", "name=yey-*", "--format", "{{.Names}}")
-	output, err := cmd.Output()
+
+	// Parse output
+	outputBuf, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
-	output = bytes.TrimSpace(output)
-	return newlines.Split(string(output), -1), nil
+	output := string(bytes.TrimSpace(outputBuf))
+	if output == "" {
+		return []string{}, nil
+	}
+	containers := newlines.Split(string(output), -1)
+
+	// Sort
+	sort.Strings(containers)
+	return containers, nil
 }
 
 func imageExists(ctx context.Context, tag string) (bool, error) {

--- a/src/internal/yey.go
+++ b/src/internal/yey.go
@@ -23,6 +23,8 @@ func hash(value string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
+// ContainerName returns the container name to use for given yey rc path
+// and context
 func ContainerName(path string, context Context) string {
 	return fmt.Sprintf(
 		"%s-%s-%s",
@@ -30,6 +32,16 @@ func ContainerName(path string, context Context) string {
 		sanitizeContextName(context.Name),
 		hash(context.String()),
 	)
+}
+
+// ContainerNamePattern returns a regexp that can be used to match all
+// container names corresponding to the given context names
+func ContainerNamePattern(contextNames []string) *regexp.Regexp {
+	pattern := "yey-.*-"
+	for _, name := range contextNames {
+		pattern += name + "-"
+	}
+	return regexp.MustCompile(pattern)
 }
 
 func sanitizeContextName(value string) string {


### PR DESCRIPTION
Allow user to multi-select context names for which to remove containers, showing only context names with actual containers.